### PR TITLE
Fix bug of customAnnotatorClass

### DIFF
--- a/src/main/scala/jigg/pipeline/Pipeline.scala
+++ b/src/main/scala/jigg/pipeline/Pipeline.scala
@@ -115,7 +115,7 @@ class Pipeline(val properties: Properties = new Properties) extends PropsHolder 
   def getAnnotatorCompanion(name: String): Option[AnnotatorCompanion[Annotator]] = {
     import scala.reflect.runtime.{currentMirror => cm}
 
-    defaultAnnotatorClassMap get(name) flatMap { clazz =>
+    getAnnotatorClass(name) flatMap { clazz =>
       val symbol = cm.classSymbol(clazz).companionSymbol
       try Some(cm.reflectModule(symbol.asModule).instance.asInstanceOf[AnnotatorCompanion[Annotator]])
       catch { case e: Throwable => None }


### PR DESCRIPTION
Previously, the command below fails:

``` bash
jigg.pipeline.Pipeline -annotators ssplit,tokenize -customAnnotatorClass.tokenize jigg.pipeline.MecabAnnotator
```

This is because instances of MecabAnnotator is created by overridden `AnnotatorCompanion.fromProps` method but in the previous version, custom annotator only supports names of which the class of that name exists (not object only, as in MecabAnnotator).
