### PR TITLE
dockerコンテナのビルド手順を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,19 +333,15 @@ To install docker, follow the [instruction](https://docs.docker.com/install/).
 To build and run PipelineServer container:
 
 ```bash
-git clone --depth 1 git@github.com:mynlp/jigg.git && cd jigg
-time docker-compose build
-docker-compose up -d
-```
-
-To download the model:
-```bash
-curl -SLO https://github.com/mynlp/jigg-models/raw/master/jigg-models.jar -o jar/jigg-models.jar
+$ git clone --depth 1 https://github.com/mynlp/jigg.git && cd jigg
+$ curl -SL https://github.com/mynlp/jigg-models/raw/master/jigg-models.jar -o jar/jigg-models.jar
+$ time docker-compose build
+$ docker-compose up -d
 ```
 
 An example of the call via `curl` is:
 ```bash
-curl --data-urlencode 'annotators=ssplit,kuromoji,jaccg' \
+$ curl --data-urlencode 'annotators=ssplit,kuromoji,jaccg' \
          --data-urlencode 'q=テレビで自転車で走っている少女を見た!' \
          'http://localhost:8080/annotate?outputFormat=xml'
 ```


### PR DESCRIPTION
コミット 3745f4c393a360002fff125d364e3c44b0c74588 において、README通りの手順ではdocker-compose buildが失敗したため手順を修正しました。

修正内容

* gitのremote URLをsshからhttpsに変更した.
* ビルド手順とモデルのダウンロード手順をまとめた.
* curlのオプションから -O を削除した.

修正後、次の環境でサンプルコマンドが動作することを確認しました。

* 環境1
    * Ubuntu 16.04
    * git 2.7.4
    * Docker 18.06.1-ce
    * docker-compose version 1.22.0, build f46880fe
    * curl 7.47.0
* 環境2
    * CentOS 7
    * git 1.8.3.1
    * Docker 1.31.1
    * docker-compose version 1.22.0, build f46880fe
    * curl 7.29.0
